### PR TITLE
Iec jiffy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ Jr	= \
 	f256/iec.asm \
 	f256/interrupt_def.asm \
 	f256/irq.asm \
+	f256/jiffy.asm \
 	f256/jr.asm \
 	f256/k2_lcd.asm \
 	f256/kbd_cbm.asm \

--- a/f256/iec.asm
+++ b/f256/iec.asm
@@ -190,7 +190,7 @@ status      .byte       ?   ; last drive status
 
             .section    kernel2
 
-IEC_DEBUG = true
+IEC_DEBUG = false
 DBG_CALL    .macro routine
             .if IEC_DEBUG
                 jsr \routine

--- a/f256/iec.asm
+++ b/f256/iec.asm
@@ -15,7 +15,7 @@ iec             .namespace
 port            .namespace
 
                 .section        kernel2 ; TODO: iec_code or somesuch
-                
+
 IEC_INPUT_PORT  = $D680 ; Read Only, this is the Value on the BUS
 ; IEC Input PORT
 ; Bit[0] IEC_DATA_i
@@ -56,7 +56,7 @@ assert_bit      .macro  BIT
                 pla
                 rts
                 .endm
-            
+
 release_bit     .macro  BIT
                 pha
                 lda     IEC_OUTPUT_PORT
@@ -64,6 +64,28 @@ release_bit     .macro  BIT
                 sta     IEC_OUTPUT_PORT
                 pla
                 rts
+                .endm
+
+assert          .macro  BITS
+                pha
+                lda     #platform.iec.port.\BITS
+                trb     platform.iec.port.IEC_OUTPUT_PORT
+                pla
+                .endm
+
+release         .macro  BITS
+                pha
+                lda     #platform.iec.port.\BITS
+                tsb     platform.iec.port.IEC_OUTPUT_PORT
+                pla
+                .endm
+
+toggle          .macro  BITS
+                pha
+                lda     #platform.iec.port.\BITS
+                trb     platform.iec.port.IEC_OUTPUT_PORT
+                tsb     platform.iec.port.IEC_OUTPUT_PORT
+                pla
                 .endm
 
 read_bit        .macro  BIT
@@ -76,7 +98,7 @@ _loop           lda     IEC_INPUT_PORT
                 pla
                 rts
                 .endm
-            
+
 bit_funcs       .segment    NAME,IN,OUT
 read_\NAME
                 .read_bit       \IN
@@ -85,7 +107,7 @@ assert_\NAME
 release_\NAME
                 .release_bit    \OUT
                 .endm
-                
+
     .bit_funcs  SREQ,   IEC_SREQ_i, IEC_SREQ_o
     .bit_funcs  ATN,    IEC_ATN_i,  IEC_ATN_o
     .bit_funcs  CLOCK,  IEC_CLK_i,  IEC_CLK_o
@@ -103,29 +125,29 @@ test_DATA   .proc
 
           ; Grab the current output state.
             ldx     IEC_OUTPUT_PORT
-            
+
           ; Prepare to release DATA
             txa
             ora     #IEC_DATA_o
             tay
-            
+
           ; Prepare to test DATA
             lda     #IEC_DATA_i
 
           ; Release DATA
             sty     IEC_OUTPUT_PORT
-            
+
           ; Test DATA
             and     IEC_INPUT_PORT
             bne     _out
-            
+
           ; Re-assert DATA if it's still low.
             stx     IEC_OUTPUT_PORT
-            
+
 _out
           ; Place the DATA state in the carry
             cmp     #1
-          
+
             ply
             plx
             pla
@@ -133,13 +155,14 @@ _out
             .pend
 
 init        .proc
+
             jsr     sleep_1ms
             stz     io_ctrl
             jsr     release_ATN
             jsr     release_DATA
             jsr     release_SREQ
             ;jsr     release_CLOCK   ; IDLE state
-            jsr     assert_CLOCK   ; IDLE state            
+            jsr     assert_CLOCK   ; IDLE state
             jsr     sleep_1ms
             jsr     sleep_1ms
             jsr     sleep_1ms
@@ -159,21 +182,38 @@ self        .namespace
 eoi_pending .byte       ?
 rx_eoi      .fill       0   ; shared with mark
 mark        .byte       ?
+jiffy       .byte       ?   ; jiffy support (0: no/not tested, <0: jiffy detected)
+temp        .byte       ?   ; bit assembly
+status      .byte       ?   ; last drive status
             .endn
             .send
 
             .section    kernel2
 
+IEC_DEBUG = true
+DBG_CALL    .macro routine
+            .if IEC_DEBUG
+                jsr \routine
+            .endif
+            .endm
+
 init
     ; Initialize the port and make sure ATN and SREQ aren't stuck.
     ; Carry set on error.
 
+            pha
+            lda     $d6a7   ; MID
+            bpl     _iec_init
+            lda     #40
+            ;sta     self.sleep20
+_iec_init
+            pla
             jsr     platform.iec.port.init
-            jsr     debug_init
+            DBG_CALL debug_init
 
           ; Bail if ATN and SRQ fail to float back up.
           ; We'll have a more thorough test when we send
-          ; our first command.            
+          ; our first command.
             nop
             nop
             nop
@@ -189,8 +229,8 @@ init
 _err
             ;jsr     wtf
             sec
-            rts        
-            
+            rts
+
 wtf
             php
             phy
@@ -203,18 +243,19 @@ _loop       lda     _wtf,y
 _done       ply
             php
             rts
-_wtf        .text   "ATN line stuck low.", $0a, 0                                    
+_wtf        .text   "ATN line stuck low.", $0a, 0
 
 TALK
 
             ora     #$40
             jsr     flush
+            stz     self.jiffy         ; re-check for jiffy
             jmp     atn_release_data   ; NOTE: does NOT drop ATN!
 
 TALK_SA
             jsr     atn_common
 
-            sei            
+            sei
             jsr     platform.iec.port.assert_DATA
             jsr     platform.iec.port.release_ATN
             jsr     platform.iec.port.release_CLOCK
@@ -223,18 +264,19 @@ TALK_SA
             cli
             rts
 
-            
+
 LISTEN
 
             ora     #$20
             jsr     flush
+            stz     self.jiffy         ; re-check for jiffy
             jmp     atn_release_data   ; NOTE: does NOT drop ATN!
-            
+
 LISTEN_SA
             jsr     atn_common
             jsr     platform.iec.port.release_ATN
             cli
-            ; TODO: WARNING!  No delay here!  
+            ; TODO: WARNING!  No delay here!
             ; TODO: IMHO, should wait at least 100us to avoid accidental turn-around!
             ; TODO: tho we do protect against this in the send code.
             rts
@@ -246,9 +288,9 @@ UNTALK      ; Detangled from C64 sources; TODO: compare with Stef's
 
         ; There should never be a need to flush here, and if you
         ; do manage to call IECOUT between a TALK/TALKSA and an
-        ; UNTALK, the C64 will flush it while ATN is asserted and 
+        ; UNTALK, the C64 will flush it while ATN is asserted and
         ; the drive will be mighty confused.
-        ; 
+        ;
         ; TODO: track the state and cause calls to IECOUT to fail.
 
           ; pre-sets CLOCK IMMEDIATELY before the ATN ... again, TODO: makes no sense
@@ -264,7 +306,7 @@ UNLISTEN    ; Detangled from C64 sources; TODO: compare with Stef's
             lda     #$3f
             jsr     flush
             jmp atn_release
-            
+
 atn_release_data
 
             sei
@@ -274,9 +316,9 @@ atn_release_data
             jsr     atn_common  ; NOTE: does NOT release ATN!  Does NOT release IRQs!
             cli
             rts
-            
+
 atn_release
-            jsr     atn_common            
+            jsr     atn_common
 
             sei
             jsr     platform.iec.port.release_ATN
@@ -291,7 +333,7 @@ atn_release
 atn_common
         ; NOTE: at present, leaves IRQs disabled on success!
 
-          ; Assert ATN; if we aren't already in sending mode, 
+          ; Assert ATN; if we aren't already in sending mode,
           ; get there:
             sei
             jsr     platform.iec.port.assert_ATN
@@ -301,7 +343,7 @@ atn_common
 
           ; Now give the devices ~1ms to start listening.
             jsr     sleep_1ms
-            
+
           ; If no one is listening, there's nothing on
           ; the bus, so signal an error.
             jsr     platform.iec.port.read_DATA
@@ -309,8 +351,8 @@ atn_common
 
           ; ATN bytes are technically never EOI bytes
             stz     self.eoi_pending
-
-            jmp send_common           
+ 
+            jmp send_common
 
 _err
           ; Always release the ATN line on error; TODO: add post delay
@@ -320,7 +362,8 @@ _err
 
 send_eoi
 send_data_eoi
-   jsr  debug_last
+            DBG_CALL  debug_last
+            jsr waste_time
             jsr     set_eoi
             jmp     send
 
@@ -333,18 +376,24 @@ send
             jsr     send_common
             cli
             rts
-            
+
 send_common
     ; A = byte
     ; Assumes we are in the sending state:
     ; the host is asserting CLOCK and the devices are asserting DATA.
     ; This part of the code should be moved to the kernel thread.
 
-    jsr debug_write
 
           ; There must be at least 100us between bytes.
-            jsr     sleep_300us
+            jsr     sleep_100us
 
+            DBG_CALL debug_write
+            jsr     platform.iec.port.read_ATN
+            bcc     _not_jiffy
+            bit     self.jiffy
+            bpl     _not_jiffy
+            jmp     jiffy.send
+_not_jiffy
 
         ; Clever cheating
 
@@ -357,7 +406,7 @@ send_common
           ; We can do this without disabling interrupts because
           ; we are also asserting DATA.
             jsr     platform.iec.port.release_CLOCK
-            
+
         ; Now we wait for all of the listeners to acknowledge.
 _wait
           ; We're still asserting DATA.
@@ -374,25 +423,25 @@ _wait
             sei
             jsr     platform.iec.port.test_DATA
             bcs     _ready
-            
+
           ; Other listeners are still busy; go back to sleep.
             bra     _wait
 
 _ready
-  jsr debug_tick
+            DBG_CALL debug_tick
             bit     self.eoi_pending
             bpl     _send
             bmi     _eoi
 
 _eoi
         ; Alas, we can't get too clever here, or the 1541 hates us.
-        
+
         ; Hard-wait the 200us for the drive to acknowledge the EOI.
         ; This duration is technically unbounded, but the ersatz
         ; listener trick during the EOI signal, and the drive
         ; already had the opportunity to delay before starting the
         ; ack, so hopefully it will stay in nominal 250us range.
-        
+
 _Tye        jsr     platform.iec.port.read_DATA
             bcs     _Tye
 
@@ -417,16 +466,22 @@ _send
         ; least 20us (with 70us more typical for clock low).
 
             phx
-            ldx     #8
+            phy
+            ldx     #7
 _loop
-          ; Don't let an interrupt put space between the clock
-          ; and the data.
-            sei     ; Already true for the first bit.
-
         ; TODO: opt test for a frame error
 
+            bne     _send_bit
+            jsr     platform.iec.port.read_ATN
+            bcs     _send_bit
+            bit     self.jiffy
+            bmi     _send_bit
+            jsr     jiffy.detect
+
+_send_bit
           ; Clock out the next bit
             jsr     platform.iec.port.assert_CLOCK
+
             jsr     sleep_20us
             lsr     a
             bcs     _one
@@ -442,16 +497,16 @@ _clock
 
             jsr     sleep_20us  ; 1541 needs this.
             jsr     platform.iec.port.release_CLOCK
-
             jsr     sleep_20us
+            jsr     platform.iec.port.release_DATA
             dex
-            bne     _loop
+            bpl     _loop
+            ply
             plx
-            
+
           ; Finish the last bit and wait for the listeners to ack.
           ; Again do this synchronously.
             sei
-            jsr     platform.iec.port.release_DATA
             jsr     platform.iec.port.assert_CLOCK
 
         ; Now wait for listener ack.  Of course, if there are
@@ -463,15 +518,15 @@ _clock
     ; to completely change the code below.
 
 .if true
-        jsr     debug_test  ; T
+            ;DBG_CALL     debug_test  ; T
 _ack        jsr     platform.iec.port.read_DATA
             bcs     _ack
-        jsr     debug_ACK   ; A
+            ;DBG_CALL     debug_ACK   ; '
             clc
             rts
-.else            
+.else
           ; Timing here isn't critical
-            cli    
+            cli
 
           ; Test the port every 20us for up to 1ms.
             lda     #50
@@ -488,11 +543,12 @@ _done
 sleep_20us
             phx
             ldx     #20
+            ;ldx     self.sleep20
 _loop       dex
             bne     _loop
             plx
             rts
-            
+
 sleep_100us
             phx
             ldx     #5
@@ -500,24 +556,24 @@ _loop       jsr     sleep_20us
             dex
             bne     _loop
             plx
-            rts                
+            rts
 
 sleep_300us
             jsr     sleep_100us
             jsr     sleep_100us
             jsr     sleep_100us
             rts
-            
+
 sleep_1ms
             jsr     sleep_300us
             jsr     sleep_300us
             jsr     sleep_300us
             jmp     sleep_100us
-            
+
 
 recv_data
-    
-    ;jsr debug_read    
+
+    DBG_CALL debug_read
 
         ; Assume not EOI until proved otherwise
             stz     self.rx_eoi
@@ -527,7 +583,7 @@ recv_data
 _wait1      jsr     platform.iec.port.read_CLOCK
             bcc     _wait1
 
-    ;jsr debug_tick
+    ;DBG_CALL debug_tick
 
 _ready
           ; Sadly, we must do the rests with interrupts disabled.
@@ -540,8 +596,8 @@ _ready
           ; Wait for all other listeners to signal
 _wait2      jsr     platform.iec.port.read_DATA
             bcc     _wait2
-    ;jsr debug_tick
-    
+    ;DBG_CALL debug_tick
+
           ; Wait for the first bit or an EOI condition
           ; Each iteration takes 6-7us
             lda     #0      ; counter
@@ -555,7 +611,7 @@ _eoi
             lda     self.rx_eoi
             bmi     _error
 
-    jsr debug_last
+    DBG_CALL debug_last
           ; Ack the EOI; we can enable IRQs for this.
             jsr     platform.iec.port.assert_DATA
             cli
@@ -563,11 +619,11 @@ _eoi
             jsr     sleep_20us
             jsr     sleep_20us
 
-          ; Set the EOI flag.  
+          ; Set the EOI flag.
             dec     self.rx_eoi ; TODO: error on second round
-          
+
           ; Go back to the ready state
-            bra     _ready            
+            bra     _ready
 
 _error
             cli
@@ -584,7 +640,7 @@ _wait_fall  jsr     platform.iec.port.read_CLOCK
 
 _wait_rise  jsr     platform.iec.port.read_CLOCK
             bcc     _wait_rise
-           
+
             jsr     platform.iec.port.read_DATA
             ror     a
             dex
@@ -603,9 +659,9 @@ _wait_rise  jsr     platform.iec.port.read_CLOCK
             jsr     sleep_20us  ; Seems to be missing the ack.
             jsr     sleep_20us  ; Seems to be missing the ack.
             jsr     sleep_20us  ; Seems to be missing the ack.
-            
-    ;jsr debug_ACK
-    jsr debug_write
+
+    ;DBG_CALL debug_ACK
+    DBG_CALL debug_write
 
           ; Return EOI in NV
             clc
@@ -635,8 +691,12 @@ IOINIT
 IECIN
     ; Receives a byte into A;
     ; NV set on EOI
+            bit     self.jiffy
+            bpl     _not_jiffy
+            jmp     jiffy.receive
+_not_jiffy
             jmp     recv_data
-            
+
 IECOUT
 
     ; Sends the byte in A.
@@ -656,7 +716,7 @@ IECOUT
         stz     delayed
 
       ; Queue the new byte
-_queue          
+_queue
         sta     queue
         dec     delayed
         rts
@@ -694,15 +754,15 @@ probe_device    ; Soft reset
 
         phy
         tay
-    
+
         jsr     LISTEN
         bcs     _out
 
         lda     #$0f
         jsr     DEV_RECV
         bcs     _out
-        
-        lda     #'U' 
+
+        lda     #'U'
         jsr     IECOUT
         lda     #'I'    ; TODO: test 'J' (hard) instead.
         jsr     IECOUT
@@ -711,7 +771,7 @@ probe_device    ; Soft reset
         tya
         jsr     UNLISTEN
         plp
-        
+
 _out
         ply
         rts
@@ -723,7 +783,7 @@ clear_status
 
         phy
         tay
-    
+
         jsr     TALK
         bcs     _out
 
@@ -731,30 +791,61 @@ clear_status
         lda     #$0f
         jsr     DEV_SEND
         bcs     _close
-        
+
+        stz     self.status
+        jsr     IECIN
+        bcs     _error
+
+        sec
+        sbc     #$30
+        asl     a
+        asl     a
+        asl     a
+        asl     a
+        sta     self.status
+
+        jsr     IECIN
+        bcs     _error
+
+        sec
+        sbc     #$30
+        tsb     self.status
+
 _loop
         jsr     IECIN
-        bcs     _close
+        bcs     _error
         bvc     _loop
-        
+        bra     _close
+
+_error
+        sec
+        lda     #$ff
+        sta     self.status
+
 _close
         php
+            DBG_CALL debug_test
         tya
         jsr     UNTALK
         plp
-        
+
 _out
         ply
+        lda     self.status
+        cmp     #0
         rts
 
+waste_time rts
+            
             .send
 
+.if IEC_DEBUG
             .section    dp
 screen      .word       ?
 read        .byte       ?
             .send
 
-            .section    kernel2            
+            .section    kernel2
 
 debug_init
             pha
@@ -766,19 +857,23 @@ debug_init
             rts
 
 debug_write
-            stz     read
-        jsr     port.read_ATN   ; cs->high->not asserted
-        ror     read            ; underline->not asserted
-            jmp     print_hex
+            pha
+            lda     #$00
+            jsr     platform.iec.port.read_ATN   ; cs->high->not asserted
+            ror     a                            ; inverted->asserted
+            eor     #$80
+            sta     read
+            pla
+            ;jmp     print_hex
 
 print_hex
             php
             pha
-            stz io_ctrl
-            jsr port.read_ATN
-            bcc _x
-            jsr     debug_print
-            bra     _done
+            ;stz io_ctrl
+            ;jsr platform.iec.port.read_ATN
+            ;bcc _x
+            ;jsr     debug_print
+            ;bra     _done
 _x
             phy
             jsr     _hex
@@ -786,13 +881,14 @@ _x
 _done
             pla
             plp
+            stz     read
             rts
 _hex
             pha
-            lsr     a            
-            lsr     a            
-            lsr     a            
-            lsr     a            
+            lsr     a
+            lsr     a
+            lsr     a
+            lsr     a
             jsr     _digit
             pla
             and     #$0f
@@ -806,7 +902,7 @@ _digit
             jmp     debug_print
 _digits     .text   "0123456789abcdef"
 
-debug_tick rts
+debug_tick
             php
             pha
             lda     #'.'
@@ -822,7 +918,7 @@ debug_ACK
             pla
             plp
             rts
-debug_EOI  rts
+debug_error
             php
             pha
             lda     #'E'
@@ -830,7 +926,7 @@ debug_EOI  rts
             pla
             plp
             rts
-              
+
 debug_last
             php
             pha
@@ -840,7 +936,7 @@ debug_last
             plp
             rts
 
-debug_test rts
+debug_test
             php
             pha
             lda     #'T'
@@ -848,8 +944,8 @@ debug_test rts
             pla
             plp
             rts
-                       
-debug_read rts
+
+debug_read  rts
             php
             pha
             lda     #'R'
@@ -857,24 +953,31 @@ debug_read rts
             pla
             plp
             rts
-                       
-debug_print rts
+
+debug_print
             phy
             ldy     #2
             sty     io_ctrl
-            ora     read
-            eor     #$80
+            sta     (screen)
+            ldy     #3
+            sty     io_ctrl
+            lda     #$f1
+            bit     read
+            bpl     _setcol
+            lda     #$1f
+_setcol
             sta     (screen)
             stz     io_ctrl
             inc     screen
             bne     _out
             inc     screen+1
-_out            
+_out
             ply
             rts
-   
+
             .send
-            
+.endif
+
 
             .endn
             .endn

--- a/f256/jiffy.asm
+++ b/f256/jiffy.asm
@@ -185,14 +185,14 @@ _rev_loop
             .endproc
 
 detect      .proc
-            ; just return if not running on an X2 core as the timings will be off
+            ; just return if not running on an X1 core as the timings will be off
             bit     $d6a7
-            bmi     _detect
+            bpl     _detect
             rts
 
 _detect
             jsr     platform.iec.port.assert_CLOCK
-            ; TODO: measure with non jiffy drive to see if this matches 400us at 12MHz
+            ; TODO: measure with non jiffy drive to see if this matches 400us at 6MHz
             ldy     #61
 _loop
             jsr     platform.iec.port.read_DATA

--- a/f256/jiffy.asm
+++ b/f256/jiffy.asm
@@ -1,0 +1,249 @@
+; Jiffy implementation Copyright 2025 Matthias Brukner <mbrukner@gmail.com>
+; SPDX-License-Identifier: GPL-3.0-only
+
+            .cpu        "w65c02"
+
+
+            .namespace  platform
+jiffy       .namespace
+            .section    kernel2
+
+            .with platform.iec
+JIFFY_DEBUG = IEC_DEBUG
+DBG_CALL    .macro routine
+            .if JIFFY_DEBUG
+            jsr \routine
+            .endif
+            .endm
+
+init        .proc
+            rts
+            .endproc
+
+            ; ------------------------------------------- Jiffy transfers----
+            ; Translation tables for sending out data, going from 4 bits to
+            ; two bit pairs, aligned with IEC output register so it is easy
+            ; and cheap to send out.
+
+            ; Bit[0] IEC_DATA_o
+            ; Bit[1] IEC_CLK_o
+
+            ; HIGH nibble (7..4)
+tx_high
+            .byte   $0f, $0d, $0e, $0c, $07, $05, $06, $04
+            .byte   $0b, $09, $0a, $08, $03, $01, $02, $00
+
+            ; LOW nibble (3..0)
+tx_low
+            .byte   $f0, $b0, $e0, $a0, $70, $30, $60, $20
+            .byte   $d0, $90, $c0, $80, $50, $10, $40, $00
+
+send        .proc
+            ; A = byte
+            ; Assumes we are in the sending state:
+            ; the host is asserting CLOCK and the device is asserting DATA.
+
+            ; prepare the bits to be sent so we can push them to IEC output
+            ; efficiently during the transfer--which is timing critical
+            phx
+            pha
+            lsr     a
+            lsr     a
+            lsr     a
+            lsr     a
+            tax
+            lda     tx_high,x
+            sta     self.temp
+            pla
+            and     #$0f
+            tax
+            lda     tx_low,x
+            ora     self.temp
+
+            ; Jiffy: wait for device to release DATA, allow interrupts while waiting
+            cli
+_wait
+            jsr     platform.iec.port.test_DATA
+            bcs     _ready
+
+            jsr     sleep_20us
+            bra     _wait
+
+_ready
+            sei
+            ldx     #4
+            ; Release CLOCK for 11-13 usecs to indicate start of transfer.
+            jsr     platform.iec.port.release_CLOCK
+
+            ; Timing now is critical, bit timings in usec after CLOCK release:
+            ; (10, 20, 31, 41) send
+            jsr     sleep_5us
+_loop
+            pha
+            and     #$03
+            ora     #(port.IEC_SREQ_o | port.IEC_ATN_o)
+            sta     port.IEC_OUTPUT_PORT
+            jsr     sleep_10us
+
+            pla
+            lsr     a
+            lsr     a
+            dex
+            bne     _loop
+
+            bit     platform.iec.self.eoi_pending
+            bpl     _no_eoi
+_eoi
+            jsr     platform.iec.port.release_CLOCK ; signal EOI
+_no_eoi
+            jsr     platform.iec.port.release_DATA
+            ; TODO: verify timing
+            jsr     sleep_10us
+
+            jsr     platform.iec.port.read_DATA
+            bcc     _ack
+            DBG_CALL     debug_error
+            bra     _end
+_ack
+            DBG_CALL     debug_ACK
+_end
+            jsr     platform.iec.port.assert_CLOCK  ; back to idle state asserting CLOCK
+            jsr     sleep_20us
+            plx
+            rts
+            .endproc
+
+receive     .proc
+            ; (17, 30, 41, 54) receive
+
+            ; Assume not EOI until proved otherwise
+            stz     self.rx_eoi
+
+            ; Wait for the sender to have a byte
+            stz     self.temp
+            phx
+            ldx     #4
+
+            ;cli
+            sei
+_wait1      jsr     platform.iec.port.read_CLOCK
+            bcc     _wait1
+
+            jsr     sleep_20us  ; give the drive some time to catch up
+            jsr     sleep_20us  ; give the drive some time to catch up
+            ;sei
+
+            ; Signal we are ready to receive
+            jsr     platform.iec.port.release_DATA
+
+            jsr     sleep_4us
+            ; Clock in the bits, 2 at a time, keep the result in temp
+_jiffy_read
+            jsr     sleep_4us
+            lda     port.IEC_INPUT_PORT
+            and     #$03
+            asl     self.temp
+            asl     self.temp
+            ora     self.temp
+            sta     self.temp
+            dex
+            bne     _jiffy_read
+
+            ; All bits transferred, now check data signal (EOI indication)
+            jsr     sleep_10us
+
+            jsr     platform.iec.port.assert_DATA
+            jsr     platform.iec.port.read_CLOCK
+            bcc     _no_eoi
+            ; Set the EOI flag.
+            dec     self.rx_eoi
+            DBG_CALL debug_last
+_no_eoi
+            cli
+
+            ; reshuffle bits to in the correct order
+            lda     self.temp
+            ldx     #8
+            stz     self.temp
+_rev_loop
+            lsr     a
+            rol     self.temp
+            dex
+            bne     _rev_loop
+            lda     self.temp
+
+            plx
+
+            ;DBG_CALL debug_ACK
+            DBG_CALL debug_write
+
+            ; Return EOI in NV
+            clc
+            bit     self.rx_eoi
+            ora     #0
+            rts
+            .endproc
+
+detect      .proc
+            ; just return if not running on an X2 core as the timings will be off
+            bit     $d6a7
+            bmi     _detect
+            rts
+
+_detect
+            jsr     platform.iec.port.assert_CLOCK
+            ; TODO: measure with non jiffy drive to see if this matches 400us at 12MHz
+            ldy     #61
+_loop
+            jsr     platform.iec.port.read_DATA
+            bcc     _detected
+            dey
+            bne     _loop
+            rts
+_detected
+            ldy     #20
+_wait_loop
+            jsr     platform.iec.port.read_DATA
+            bcs     _out
+            dey
+            bne     _wait_loop
+_out
+            dec     self.jiffy ; 0 -> ff
+            rts
+            .endproc
+
+
+            ; NB: the timing values need not to be taken literally;
+            ;     they have been manually adjusted to match Jiffy timings
+sleep_4us   .proc
+            phx
+            ldx     #4
+_loop       dex
+            bne     _loop
+            plx
+            rts
+            .endproc
+
+sleep_5us   .proc
+            phx
+            ldx     #6
+_loop       dex
+            bne     _loop
+            plx
+            rts
+            .endproc
+
+sleep_10us  .proc
+            phx
+            ldx     #7
+_loop       dex
+            bne     _loop
+            plx
+            rts
+            .endproc
+
+
+            .endwith ; platform.iec
+            .send ; kernel2
+            .endn ; jiffy
+            .endn ; platform

--- a/hardware/iec.asm
+++ b/hardware/iec.asm
@@ -89,7 +89,7 @@ _loop       sta     channels,x
 
           ; Wait before enabling IEC operations.
             stz     awake
-            lda     #5
+            lda     #1
             jsr     kernel.clock.insert
 
             phy


### PR DESCRIPTION
This PR implements Jiffy protocol for the F256K, both with X1 and X2 cores. This has been tested with 1541, 1571 and 1581. There is an auto detect mechanism that is being triggered on every talk/listen session, as with the original implementation. Power LED indicates Jiffy reads by flashing orange.