### PR TITLE
Fix a bug causing spurious joystick events

### DIFF
--- a/f256/kbd_f256k2.asm
+++ b/f256/kbd_f256k2.asm
@@ -201,11 +201,13 @@ joysticks
         sta     kernel.event.entry.type,y
 
         lda     JRA
+        ora     #$80
         sta     joy0
         eor     #$ff
         sta     kernel.event.entry.joystick.joy0,y
         
         lda     JRB
+        ora     #$80
         sta     joy1
         eor     #$ff
         sta     kernel.event.entry.joystick.joy1,y
@@ -220,9 +222,11 @@ scan
 
       ; Check the joysticks
         lda     JRA
+        ora     #$80
         eor     joy0
         bne     _joysticks
         lda     JRB
+        ora     #$80
         eor     joy1
         beq     _keyboard
 


### PR DESCRIPTION
Problem: The joystick handler was generating false/spurious joystick events, causing event queue overflow

Root Cause: Bit 7 of the joystick registers (JRA and JRB) was fluctuating or producing inconsistent reads. Since the code detects joystick state changes by comparing current register values against previously stored values (joy0/joy1), instability in bit 7 would trigger change detection even when no actual joystick input occurred.

Fix: Added ora #$80 to mask bit 7 high where JRA and JRB are read